### PR TITLE
caiocezart/class02-exercise-fix

### DIFF
--- a/classes/02class/exercises/c02-network11/README.md
+++ b/classes/02class/exercises/c02-network11/README.md
@@ -15,6 +15,7 @@ Repeat exercise from last class where you have to:
   - attach your private SG to your public instance
 - access to your public instance using SSH
 - FROM your PUBLIC instance, SSH to your private one
+- from the PRIVATE instance, try to ping 8.8.8.8 to check internet connection through NATGW
 
 However this time, use your custom created subnets instead of the AWS default ones.
 


### PR DESCRIPTION
# Description

Quick exercise fix to  class02 exercise 11 where you have to create an instance on public instance an another  one on  private  subnet. No internet connectivity from private  subnet  was requested.


## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [x] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
