### PR TITLE
Fixed typo on README file

### DIFF
--- a/classes/03class/docker/README.md
+++ b/classes/03class/docker/README.md
@@ -271,7 +271,7 @@ The [ECS Service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ec
 It's also responsible by associating the containers running with a specific load balance, so the traffic trying to access the service can be balanced between multiple containers.
 
 #### ECS Task definition
-The [ECS Task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) describes the container execution parmeters. 
+The [ECS Task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) describes the container execution parameters. 
 
 The Task definition contains information about the image used, resources(CPU and memory) that will be made available for that container, AWS IAM Role assumed by the container and volumes to be mounted, so when a new container is created it will always use the same configurations.
 


### PR DESCRIPTION
Fixed small typo in the README file

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [x] Documentation update
- [ ] Repo management
