### PR TITLE
Add dashboard target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ export FOLDER_NAME?=
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-dashboard:
-	$(ROOT_DIR)/scripts/dashboard.sh
+dashboard:   # Creates a scorecard dashboard in CSV. You can pass GH_USER and GH_TOKEN to authenticate in GitHub
+	$(ROOT_DIR)/scripts/dashboard.sh ${GH_USER} ${GH_TOKEN}
 
 presentation:
 	docker-compose up -d

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ export REPO_NAME?=academy
 export BRANCH_NAME?=
 export FOLDER_NAME?=
 
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+dashboard:
+	$(ROOT_DIR)/scripts/dashboard.sh
+
 presentation:
 	docker-compose up -d
 	sleep 5

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you want to make part of the team behind this, get in touch on help@devopsaca
     - [Available labs](#available-labs)
   - [Projects](#projects)
 - [Contributors and Instructors](#contributors-and-instructors)
+  - [Create a dashboard (CSV file) about  exercise submissions](#create-a-dashboard-csv-file-about-exercise-submissions)
   - [Presentation format](#presentation-format)
 - [Authors](#authors)
   - [Caio Trevisan](#caio-trevisan)
@@ -214,9 +215,22 @@ Example:
 
 # Contributors and Instructors
 
+## Create a dashboard (CSV file) about  exercise submissions
+
+It will use the file `labs.txt`and `students.txt`from the `scripts/` folder (TO BE IMPROVED FOR FLEXIBILITY).
+
+Run:  `make dashboard`
+
+
 ## Presentation format
 
 * We are using plain README.md files with markdown or [GitPitch](https://gitpitch.com/docs/markdown-features/basics/) for slideshow presentations
+
+* Generate the presentation by running: 
+  * `make presentation`
+* Generate a README.md file from the PITCHME.md file:
+  * `make pitchme_to_readme`
+
 * For GitPitch, use PITCHME.md files and subfolders using query string "p=FOLDERNAME" with the class name
 * GitPitch can run either online (out-of-the-box for Github public repos):
     * Online: access `https://gitpitch.com/${ORG_NAME}/${REPO_NAME}/${BRANCH_NAME}?p=${FOLDER_NAME}`. Folder must contain a PITCHME.md file.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ It will use the file `labs.txt`and `students.txt`from the `scripts/` folder (TO 
 
 Run:  `make dashboard`
 
+Optionally you can pass the Github User and Token, so the API calls are not throttled.
+
+Run:  `make dashboard GH_USER=<YOUR_USER> GH_TOKEN=<YOUR_TOKEN>`
 
 ## Presentation format
 

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -1,4 +1,5 @@
-BASEDIR=$PWD
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[1;34m'

--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -8,8 +8,10 @@ GITHUB_URL="https://api.github.com/repos/devopsacademyau/academy"
 if [ "${GH_USER}" == "" ] || [ "${GH_TOKEN}" == "" ]
 then
     TOKEN=""
+    echo ** NO AUTH **
 else
     TOKEN="-u ${GH_USER}:${GH_TOKEN}"
+    echo ** Using GitHub token **
 fi
 
 mkdir ${BASEDIR}/results


### PR DESCRIPTION
# Description

Add dashboard target to Makefile.

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
