### PR TITLE
adding the applications folder to be ignored as well

### DIFF
--- a/.github/content-label.yaml
+++ b/.github/content-label.yaml
@@ -1,2 +1,2 @@
-- regExp: "^((?!exercises\/[a-zA-Z0-9|-]+\/[a-zA-Z0-9_|-]+\/).)*$"
+- regExp: "^((?!(exercises\/[a-zA-Z0-9|-]+\/[a-zA-Z0-9_|-]+\/)|(^applications\/)).)*$"
   labels: ["REPO-CONTENT"]


### PR DESCRIPTION
# Description
Adding applications folder to be ignored for the CONTENT label.

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [X] Repo management
