### PR TITLE
Making application.sh portable across different flavours of *nix.

### DIFF
--- a/applications/application.sh
+++ b/applications/application.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 echo "## uname" > output.txt
 uname -a >> output.txt
 echo "## git " >> output.txt


### PR DESCRIPTION
# Description

The `application.sh` did not run on my computer (MacOS) because the `bash` is in a different location: `/bin/bash` -- using the syntax in this PR will allow it to run regardless of where bash resides.

More details:
- https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html
- https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
- [X] None of the above