### PR TITLE
Update format of git exercises to the new pattern

### DIFF
--- a/classes/01class/exercises/README.md
+++ b/classes/01class/exercises/README.md
@@ -5,9 +5,9 @@ For instructions on how to submit your work, [please check the main repository R
 ## Git
 
 - [Merging and Rebasing (c01-git01)](/classes/01class/exercises/c01-git01/README.md)
-- [Everyday questions (c01-git02)](/classes/01class/exercises/c01-git02/README.md)
 - [Big file (c01-git03)](/classes/01class/exercises/c01-git03/README.md)
 - [Secrets (c01-git04)](/classes/01class/exercises/c01-git04/README.md)
+- [Everyday questions (Optional)](/classes/01class/exercises/c01-git02/README.md)
 
 ## AWS
 

--- a/classes/01class/exercises/c01-git01/ANSWER.md
+++ b/classes/01class/exercises/c01-git01/ANSWER.md
@@ -1,0 +1,12 @@
+# c01-git01
+
+## Commands executed
+
+- [c01-git01-1.md](c01-git01-1.md)
+- [c01-git01-1.md](c01-git01-2.md)
+- [c01-git01-1.md](c01-git01-3.md)
+
+<!-- Don't change anything below this point-->
+<!-- Before commiting, remove both commented lines--> 
+***
+Answer for exercise [c01-git01](https://github.com/devopsacademyau/academy/blob/23cc1dfa31e85651e3cdc1b0ef38da21518841ba/classes/01class/exercises/c01-git01/README.md)

--- a/classes/01class/exercises/c01-git01/ANSWER.md
+++ b/classes/01class/exercises/c01-git01/ANSWER.md
@@ -2,11 +2,25 @@
 
 ## Commands executed
 
-- [c01-git01-1.md](c01-git01-1.md)
-- [c01-git01-1.md](c01-git01-2.md)
-- [c01-git01-1.md](c01-git01-3.md)
+1. Commands typed to solve the "Merging" exercise
+```
+
+
+```
+
+2. Commands typed to solve the "Rebasing" exercise
+```
+
+
+```
+
+3. Commands typed to solve the "Revert and reset" exercise
+```
+
+
+```
 
 <!-- Don't change anything below this point-->
 <!-- Before commiting, remove both commented lines--> 
 ***
-Answer for exercise [c01-git01](https://github.com/devopsacademyau/academy/blob/23cc1dfa31e85651e3cdc1b0ef38da21518841ba/classes/01class/exercises/c01-git01/README.md)
+Answer for exercise [c01-git01](https://github.com/devopsacademyau/academy/blob/c54d252bda58575e9dc9f92718237bed58aae772/classes/01class/exercises/c01-git01/README.md)

--- a/classes/01class/exercises/c01-git01/README.md
+++ b/classes/01class/exercises/c01-git01/README.md
@@ -1,12 +1,18 @@
 ## Merging and Rebasing (c01-git01)
 
-1. Access https://learngitbranching.js.org/ (TIP: if you want to start over, just type `reset`)
-2. Merging exercise:
+1. Access https://learngitbranching.js.org/ (**TIP**: if you want to start over, just type `reset`. To dismiss tutorial screens, type `Esc`)
+2. **c01-git01-1**: Merging exercise:
    1. type `level intro3`
-   2. Submission: Include your commands on a file **c01-git01-1.txt**
-3. Rebasing exercise:
+3. **c01-git01-2**: Rebasing exercise:
    1. type `level intro4`
-   2. Submission: Include your commands on a file **c01-git01-2.txt**
-4. Revert and reset: 
+4. **c01-git01-3**: Revert and reset:
    1. type `level rampup4`
-   2. Submission: Include your commands on a file **c01-git01-3.txt**
+
+## Submit a PR with the following files
+
+> Remember to follow the instructions on [how to submit a PR here](/README.md#exercises)s
+
+- **README.md**: copy from file [ANSWER.md](ANSWER.md), containing links to the following files with your answers:
+  - **c01-git01-1.md**: Commands typed to solve the "Merging" exercise
+  - **c01-git01-2.md**: Commands typed to solve the "Rebasing" exercise
+  - **c01-git01-3.md**: Commands typed to solve the "Revert and reset" exercise

--- a/classes/01class/exercises/c01-git01/README.md
+++ b/classes/01class/exercises/c01-git01/README.md
@@ -1,18 +1,15 @@
 ## Merging and Rebasing (c01-git01)
 
 1. Access https://learngitbranching.js.org/ (**TIP**: if you want to start over, just type `reset`. To dismiss tutorial screens, type `Esc`)
-2. **c01-git01-1**: Merging exercise:
+2. Merging exercise:
    1. type `level intro3`
-3. **c01-git01-2**: Rebasing exercise:
+3. Rebasing exercise:
    1. type `level intro4`
-4. **c01-git01-3**: Revert and reset:
+4. Revert and reset:
    1. type `level rampup4`
 
 ## Submit a PR with the following files
 
 > Remember to follow the instructions on [how to submit a PR here](/README.md#exercises)s
 
-- **README.md**: copy from file [ANSWER.md](ANSWER.md), containing links to the following files with your answers:
-  - **c01-git01-1.md**: Commands typed to solve the "Merging" exercise
-  - **c01-git01-2.md**: Commands typed to solve the "Rebasing" exercise
-  - **c01-git01-3.md**: Commands typed to solve the "Revert and reset" exercise
+- **README.md**: copy from file [ANSWER.md](ANSWER.md), containing your answers.

--- a/classes/01class/exercises/c01-git02/ANSWER.md
+++ b/classes/01class/exercises/c01-git02/ANSWER.md
@@ -1,0 +1,11 @@
+# c01-git02
+
+## Commands executed
+
+- [c01-git02-1.md](c01-git02-1.md)
+- [c01-git02-1.md](c01-git02-2.md)
+
+<!-- Don't change anything below this point-->
+<!-- Before commiting, remove both commented lines--> 
+***
+Answer for exercise [c01-git02](https://github.com/devopsacademyau/academy/blob/23cc1dfa31e85651e3cdc1b0ef38da21518841ba/classes/01class/exercises/c01-git02/README.md)

--- a/classes/01class/exercises/c01-git02/ANSWER.md
+++ b/classes/01class/exercises/c01-git02/ANSWER.md
@@ -1,11 +1,20 @@
 # c01-git02
 
-## Commands executed
+## Answers
 
-- [c01-git02-1.md](c01-git02-1.md)
-- [c01-git02-1.md](c01-git02-2.md)
+1. Is it possible to see the inner commit of squashed commit with `git rebase`?
+```
+
+
+```
+
+2. How to compare two different local repositories using `git diff`? How about remote ones, can you do the same?
+```
+
+
+```
 
 <!-- Don't change anything below this point-->
 <!-- Before commiting, remove both commented lines--> 
 ***
-Answer for exercise [c01-git02](https://github.com/devopsacademyau/academy/blob/23cc1dfa31e85651e3cdc1b0ef38da21518841ba/classes/01class/exercises/c01-git02/README.md)
+Answer for exercise [c01-git02](https://github.com/devopsacademyau/academy/blob/c54d252bda58575e9dc9f92718237bed58aae772/classes/01class/exercises/c01-git02/README.md)

--- a/classes/01class/exercises/c01-git02/README.md
+++ b/classes/01class/exercises/c01-git02/README.md
@@ -1,7 +1,7 @@
 ## Everyday questions (c01-git02 - optional)
 
-1. **file c01-git02-1.md** - Is it possible to see the inner commit of squashed commit with `git rebase`?
-2. **file c01-git02-2.md** - How to compare two different local repositories using `git diff`? How about remote ones, can you do the same?
+1. Is it possible to see the inner commit of squashed commit with `git rebase`?
+2. How to compare two different local repositories using `git diff`? How about remote ones, can you do the same?
 3. (Optional) Install [`ohmyzsh`](https://github.com/ohmyzsh/ohmyzsh) and activate the git plugin
 
 
@@ -9,6 +9,4 @@
 
 > Remember to follow the instructions on [how to submit a PR here](/README.md#exercises)
 
-- **README.md**: copy from file [ANSWER.md](ANSWER.md), containing links to the following files with your answers:
-  - **c01-git02-1.md**
-  - **c01-git02-2.md**
+- **README.md**: copy from file [ANSWER.md](ANSWER.md), containing the answers.

--- a/classes/01class/exercises/c01-git02/README.md
+++ b/classes/01class/exercises/c01-git02/README.md
@@ -1,5 +1,14 @@
-## Everyday questions (c01-git02)
+## Everyday questions (c01-git02 - optional)
 
-1. **file c01-git02-1.txt** - Is it possible to see the inner commit of squashed commit with `git rebase`?
-2. **file c01-git02-2.txt** - How to compare two different local repositories using `git diff`? How about remote ones, can you do the same?
+1. **file c01-git02-1.md** - Is it possible to see the inner commit of squashed commit with `git rebase`?
+2. **file c01-git02-2.md** - How to compare two different local repositories using `git diff`? How about remote ones, can you do the same?
 3. (Optional) Install [`ohmyzsh`](https://github.com/ohmyzsh/ohmyzsh) and activate the git plugin
+
+
+## Submit a PR with the following files
+
+> Remember to follow the instructions on [how to submit a PR here](/README.md#exercises)
+
+- **README.md**: copy from file [ANSWER.md](ANSWER.md), containing links to the following files with your answers:
+  - **c01-git02-1.md**
+  - **c01-git02-2.md**

--- a/classes/01class/exercises/c01-git03/ANSWER.md
+++ b/classes/01class/exercises/c01-git03/ANSWER.md
@@ -1,0 +1,19 @@
+# c01-git03
+
+## Questions (answer inline)
+
+1. Did you notice any difference in the size of the repo before and after adding the big file?
+
+
+2. What is the reason for this problem?
+
+
+3. How do you remove something from Git history after it is pushed to the remote repository? Which commands would you use? 
+
+
+4. What are the consequences of the previous action?
+
+<!-- Don't change anything below this point-->
+<!-- Before commiting, remove both commented lines--> 
+***
+Answer for exercise [c01-git03](https://github.com/devopsacademyau/academy/blob/23cc1dfa31e85651e3cdc1b0ef38da21518841ba/classes/01class/exercises/c01-git03/README.md)

--- a/classes/01class/exercises/c01-git03/README.md
+++ b/classes/01class/exercises/c01-git03/README.md
@@ -19,7 +19,13 @@ Perform the following commands:
 
 **Questions**
 
-Create a file **c01-git03-1.txt** answering the questions below. Include details and commands used.
 1. Did you notice any difference in the size of the repo before and after adding the big file?
-1. What is the reason for this problem?
-1. How do you remove something from Git history? Which commands would you use? What are the consequences?
+2. What is the reason for this problem?
+3. How do you remove something from Git history after it is pushed to the remote repository? Which commands would you use? 
+4. What are the consequences of the previous action?
+
+## Submit a PR with the following files
+
+> Remember to follow the instructions on [how to submit a PR here](/README.md#exercises)
+
+- **README.md**: copy from file [ANSWER.md](ANSWER.md), answering the questions

--- a/classes/01class/exercises/c01-git04/ANSWER.md
+++ b/classes/01class/exercises/c01-git04/ANSWER.md
@@ -1,0 +1,23 @@
+# c01-git04
+
+## Questions (answer inline)
+
+1. Let's suppose you remotely pushed the `my_env.txt` file above. A colleague asks you to remove this information from Git. What's your colleague worried about?
+
+
+2. If you modify the file in your workspace, then commit and push it, will it be enough to erase this password information from the repository? (It's not). Why?
+
+
+3. If you delete the file and push it, then create a new one with the rest of the information, is it enough? (It's not). Why?
+
+
+4. How to fix this? How do you remove something from Git history when it is in the remote repository?
+
+
+5. Which commands would you use? Explain what the command does.
+   
+
+<!-- Don't change anything below this point-->
+<!-- Before commiting, remove both commented lines--> 
+***
+Answer for exercise [c01-git04](https://github.com/devopsacademyau/academy/blob/23cc1dfa31e85651e3cdc1b0ef38da21518841ba/classes/01class/exercises/c01-git04/README.md)

--- a/classes/01class/exercises/c01-git04/README.md
+++ b/classes/01class/exercises/c01-git04/README.md
@@ -8,14 +8,19 @@ Perform the following commands:
     ENVIRONMENT=prod
     PASSWORD=pass1234
     ```
-1. Commit it
-3. Check the commit with `git log`
+1. Commit it to your local repository
+2. Check the log with `git log`
 
 **Questions**
 
-Create a file **c01-git04-1.txt** answering the questions below. Include details and commands used.
-1. Let's suppose you remotely pushed your `my_env.txt` file. A colleague asks you to remove this information from Git. What's your colleague worried about? 
-2. If you modify the file in your workspace, then push it, will it be enough? (It's not). Why?
+1. Let's suppose you remotely pushed the `my_env.txt` file above. A colleague asks you to remove this information from Git. What's your colleague worried about?
+2. If you modify the file in your workspace, then commit and push it, will it be enough to erase this password information from the repository? (It's not). Why?
 3. If you delete the file and push it, then create a new one with the rest of the information, is it enough? (It's not). Why?
-4. How to fix this? How do you remove something from Git history?
-5. Which commands would you use? What are the consequences for other developers?
+4. How to fix this? How do you remove something from Git history when it is in the remote repository?
+5. Which commands would you use? Explain what the command does.
+
+## Submit a PR with the following files
+
+> Remember to follow the instructions on [how to submit a PR here](/README.md#exercises)
+
+- **README.md**: copy from file [ANSWER.md](ANSWER.md), answering the questions above. Include details and commands used.

--- a/scripts/dashboard/labs.txt
+++ b/scripts/dashboard/labs.txt
@@ -1,7 +1,6 @@
 c01-aws01
 c01-aws02
 c01-git01
-c01-git02
 c01-git03
 c01-git04
 c02-network01


### PR DESCRIPTION
# Description

- Add ANSWER.md to c01-git exercises
- Update README.md of c01-git exercises
- Deprecate exercise c01-git02

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [x] Class content (instructors/admins)
- [ ] Documentation update
- [x] Repo management
