### PR TITLE
add feature to send message to slack - testchannel

### DIFF
--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -1,6 +1,6 @@
-on:
-  schedule:
-  - cron: "0 0 * * *"
+on: 
+schedule:
+- cron: "0 10 * * 1,5"
     
 name: Dashboard Generation
 jobs:
@@ -14,6 +14,9 @@ jobs:
       env:
         GOOGLE_KEY: ${{ secrets.DASHBOARD_GOOGLE_KEY }}
         SHEET_KEY: ${{ secrets.DASHBOARD_SHEET_KEY }}
-        WKS_NAME: "Dashboard"
         GH_USER: ${{ secrets.DASHBOARD_GH_USER }}
         GH_TOKEN: ${{ secrets.DASHBOARD_GH_TOKEN }}
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+

--- a/.github/workflows/dashboard.yaml
+++ b/.github/workflows/dashboard.yaml
@@ -19,4 +19,6 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+        PUBLISH_URL: ${{ secrets.PUBLISH_URL }}
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 dashboard:
 	$(RUNNER) python-da /app/scripts/dashboard/run.sh
+	$(RUNNER) aws-cli /app/scripts/dashboard/publish.sh
 
 
 presentation:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,16 @@ services:
     environment:
       - GOOGLE_KEY
       - SHEET_KEY
-      - WKS_NAME
       - GH_USER
       - GH_TOKEN
-    
+  aws-cli:
+    image: amazon/aws-cli
+    volumes:
+      - ${PWD}:/app
+      - ${HOME}/.aws:/root/.aws
+    environment:
+      - SLACK_WEBHOOK
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+    entrypoint:
+      - bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - ${HOME}/.aws:/root/.aws
     environment:
       - SLACK_WEBHOOK
+      - SLACK_CHANNEL
+      - PUBLISH_URL
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
     entrypoint:

--- a/scripts/dashboard/dashboard.py
+++ b/scripts/dashboard/dashboard.py
@@ -77,7 +77,6 @@ print("Creating Chart")
 
 df = pd.DataFrame(wks.get_all_records())
 
-
 # Plot Style
 plt.style.use('ggplot')
 plt.figure(figsize=(12,5))
@@ -101,6 +100,11 @@ plt.legend(bbox_to_anchor=(1.01,0.5), loc="center left", prop=fontP)
 plt.title("Exercises Completion Progress", loc='center', fontsize=14, fontweight=0, color='orange')
 plt.xlabel("Dates")
 plt.ylabel("% Completed")
+
+# Set Y range
+plt.axis([0, 10, -1, 100])
+
+# Save chart
 plt.savefig('chart.png', bbox_inches='tight')
 
 print("Chart creation completed")

--- a/scripts/dashboard/labs.txt
+++ b/scripts/dashboard/labs.txt
@@ -1,7 +1,6 @@
 c01-aws01
 c01-aws02
 c01-git01
-c01-git02
 c01-git03
 c01-git04
 c02-network01

--- a/scripts/dashboard/labs.txt
+++ b/scripts/dashboard/labs.txt
@@ -1,6 +1,7 @@
 c01-aws01
 c01-aws02
 c01-git01
+c01-git02
 c01-git03
 c01-git04
 c02-network01

--- a/scripts/dashboard/publish.sh
+++ b/scripts/dashboard/publish.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+cd /app/scripts/dashboard
+
+DATE=$(date +%Y-%m-%d)
+echo "Saving files to S3"
+aws s3 cp ./chart.png s3://devopsacademy.com.au/progression-chart/chart.png
+
+echo "Publishing Slack message"
+curl -X POST -H 'Content-type: application/json' \
+  ${SLACK_WEBHOOK} \
+  --data '{
+  "channel": "test-automation",
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": ":siren-alert: *Labs Progression Update!* :siren-alert:\n:baby-yoda: Those lines to the top of the chart we need to get. Yes, hrrmmm."
+      }
+    },
+    {
+      "type": "image",
+      "title": {
+        "type": "plain_text",
+        "text": "Updated Progression"
+      },
+      "block_id": "image4",
+      "image_url": "https://s3-ap-southeast-2.amazonaws.com/devopsacademy.com.au/progression-chart/chart.png",
+      "alt_text": "Labs Progression"
+    }
+  ]
+}'

--- a/scripts/dashboard/run.sh
+++ b/scripts/dashboard/run.sh
@@ -4,3 +4,4 @@ mkdir -p ~/.config/gspread/
 echo $GOOGLE_KEY |base64 -d > ~/.config/gspread/service_account.json
 ./dashboard.sh
 python3 dashboard.py
+

--- a/scripts/dashboard/slack_payload.json
+++ b/scripts/dashboard/slack_payload.json
@@ -1,15 +1,5 @@
-#!/bin/bash
-cd /app/scripts/dashboard
-
-DATE=$(date +%Y-%m-%d)
-echo "Saving files to S3"
-aws s3 cp ./chart.png s3://devopsacademy.com.au/progression-chart/chart.png
-
-echo "Publishing Slack message"
-curl -X POST -H 'Content-type: application/json' \
-  ${SLACK_WEBHOOK} \
-  --data '{
-  "channel": "test-automation",
+{
+  "channel": "SLACK_CHANNEL",
   "blocks": [
     {
       "type": "section",
@@ -25,8 +15,8 @@ curl -X POST -H 'Content-type: application/json' \
         "text": "Updated Progression"
       },
       "block_id": "image4",
-      "image_url": "https://devopsacademy.com.au/progression-chart/chart.png",
+      "image_url": "PUBLISH_URL/chart-CHART_DATE.png",
       "alt_text": "Labs Progression"
     }
   ]
-}'
+}


### PR DESCRIPTION
# Description
Adding step to send message with progression dashboard to a slack channel(test-channel for the moment). The workflow will run Mondays and Fridays at 8pm.


## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [x] Documentation update
- [x] Repo management
