### PR TITLE
Suggestion of minor changes to README.md instructions for exercise c01-aws02

### DIFF
--- a/classes/01class/exercises/c01-aws02/ANSWER.md
+++ b/classes/01class/exercises/c01-aws02/ANSWER.md
@@ -12,7 +12,7 @@ Add your commands and their outputs here
 Add your commands and their outputs here
 ```
 
-- Commands to copy the S3 file to a folder inside the instace (executed from inside the EC2 Instance):
+- Commands to copy the S3 file to a folder inside the instance (executed from inside the EC2 Instance):
 ```
 Add your commands and their outputs here
 ```
@@ -23,6 +23,6 @@ Add comments here
 ```
 
 <!-- Don't change anything below this point-->
-<!-- Before commiting, remove both commented lines--> 
+<!-- Before committing, remove both commented lines--> 
 ***
 Answer for exercise [c01-aws02](https://github.com/devopsacademyau/academy/blob/635775538e8ad7793b305f48064b09e23c626fb7/classes/01class/exercises/c01-aws02/README.md)

--- a/classes/01class/exercises/c01-aws02/README.md
+++ b/classes/01class/exercises/c01-aws02/README.md
@@ -1,8 +1,8 @@
 ## S3 (C01-aws02)
 
 - Use the CLI to create a S3 bucket and upload a file to it.
-- Access the file on the S3 bucket from any the EC2 instance created in the previous exercise.
-- Submit a PR to the DevOpsAcademy repo under the `/classes/01class/exercises/c01-aws02/<github-username>` folder of this class with a brief description of what you did to achieve this objective. The file containing the solution you used must be named README.md
+- Access the file on the S3 bucket from any of the EC2 instances created in the previous exercise.
+- Submit a PR to the DevOpsAcademy repo under the `/classes/01class/exercises/c01-aws02/<github-username>` folder of this class with a brief description of what you did to achieve this objective (using AWS CLI). The file containing the solution you used must be named README.md
 
 ## Submit a PR with the folowing file:
 - README.md based on the [ANSWER.md](ANSWER.md) file with the commands requested. 


### PR DESCRIPTION
# Description

Exercise:  This is not a solution to an exercise.

Student Name: Carlos Zambrano

> I've suggested some small changes to the file:
classes/01class/exercises/c01-aws02/README.md
One is a minor wording thing, the other is to make the use of the AWS CLI more explicit for the whole exercise. I didn't get it all was via AWS CLI.

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
