### PR TITLE
fix terraform to use for_each for github team members

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,17 @@ We highly recommend doing the exercises from this repository. However, you will 
 
 - Create a new branch from `master`
 - Open the file [/scripts/tf/github.com/team-external-students.tf](/scripts/tf/github.com/team-external-students.tf)
-- Add your GitHub username in an alphabetical order (that will help you avoid merge conflicts)
+- Add your GitHub username on the `members` variable in an alphabetical order (that will help you avoid merge conflicts)
+
+i.e: username is `caiocezart`
+
 ```
-{
-  name: "caiocezart",
-  role: "member"
-}
+members = [
+  "aaa",
+  "bbb",
+  "caiocezart",
+  "ccc"
+]
 ```
 - Save, add and commit the change
 - Raise a Pull Request

--- a/scripts/tf/github.com/2020-feb-students.tf
+++ b/scripts/tf/github.com/2020-feb-students.tf
@@ -1,63 +1,27 @@
 module "team-students-2020-feb" {
   source              = "./da-teams"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "students-2020-feb"
+  group_role          = "member"
   members             = [
-    {
-      name: "andreazzabr",
-      role: "member"
-    },
-    {
-      name: "carineoliveira",
-      role: "member"
-    },
-    {
-      name: "christina-roperto",
-      role: "member"
-    },
-    {
-      name: "deniseddi",
-      role: "member"
-    },
-    {
-      name: "drii-cavalcanti",
-      role: "member"
-    },
-    {
-      name: "faria-marcio",
-      role: "member"
-    },
-    {
-      name: "hsy3418",
-      role: "member"
-    },
-    {
-      name: "lgothelipe",
-      role: "member"
-    },
-    {
-      name: "luizfds",
-      role: "member"
-    },
-    {
-      name: "marcioanatrielo",
-      role: "member"
-    },
-    {
-      name: "starkmatt",
-      role: "member"
-    }
+    "andreazzabr",
+    "carineoliveira",
+    "christina-roperto",
+    "deniseddi",
+    "drii-cavalcanti",
+    "faria-marcio",
+    "hsy3418",
+    "lgothelipe",
+    "luizfds",
+    "marcioanatrielo",
+    "starkmatt"
   ]
 }
 
 module "y2020-feb-project1-group1" {
   source              = "./da-project"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "2020-feb-project1-group1"
-  admins_team_id      = module.team-admins.team_id
-  parent_team_id      = module.team-students-2020-feb.team_id
+  admins_team_id      = module.team-admins.id
+  parent_team_id      = module.team-students-2020-feb.id
   members             = [
     "lgothelipe",
     "luizfds",
@@ -68,11 +32,9 @@ module "y2020-feb-project1-group1" {
 
 module "y2020-feb-project1-group2" {
   source              = "./da-project"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "2020-feb-project1-group2"
-  admins_team_id      = module.team-admins.team_id
-  parent_team_id      = module.team-students-2020-feb.team_id
+  admins_team_id      = module.team-admins.id
+  parent_team_id      = module.team-students-2020-feb.id
   members             = [
     "faria-marcio",
     "starkmatt",
@@ -83,11 +45,9 @@ module "y2020-feb-project1-group2" {
 
 module "y2020-feb-project1-group3" {
   source              = "./da-project"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "2020-feb-project1-group3"
-  admins_team_id      = module.team-admins.team_id
-  parent_team_id      = module.team-students-2020-feb.team_id
+  admins_team_id      = module.team-admins.id
+  parent_team_id      = module.team-students-2020-feb.id
   members             = [
     "andreazzabr",
     "hsy3418",

--- a/scripts/tf/github.com/2020-jun-students.tf
+++ b/scripts/tf/github.com/2020-jun-students.tf
@@ -1,72 +1,23 @@
 module "team-students-2020-jun" {
   source              = "./da-teams"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "students-2020-jun"
+  group_role          = "member"
   members             = [
-    {
-      name: "alanlima",
-      role: "member"
-    },
-    {
-      name: "danielvca",
-      role: "member"
-    },
-    {
-      name: "fabioacp",
-      role: "member"
-    },
-    {
-      name: "feernandobraga",
-      role: "member"
-    },
-    {
-      name: "frdvo",
-      role: "member"
-    },
-    {
-      name: "gepifanio",
-      role: "member"
-    },
-    {
-      name: "gpavelar",
-      role: "member"
-    },
-    {
-      name: "igorjosesantos",
-      role: "member"
-    },
-    {
-      name: "jayanath",
-      role: "member"
-    },
-    {
-      name: "mail2kvanitha",
-      role: "member"
-    },
-    {
-      name: "mfreitassm",
-      role: "member"
-    },
-    {
-      name: "mrcsmonteiro",
-      role: "member"
-    },
-    {
-      name: "nimmi89",
-      role: "member"
-    },
-    {
-      name: "obrientimothya",
-      role: "member"
-    },
-    {
-      name: "shahriar048",
-      role: "member"
-    },
-    {
-      name: "zarajoy",
-      role: "member"
-    }
+    "alanlima",
+    "danielvca",
+    "fabioacp",
+    "feernandobraga",
+    "frdvo",
+    "gepifanio",
+    "gpavelar",
+    "igorjosesantos",
+    "jayanath",
+    "mail2kvanitha",
+    "mfreitassm",
+    "mrcsmonteiro",
+    "nimmi89",
+    "obrientimothya",
+    "shahriar048",
+    "zarajoy"
   ]
 }

--- a/scripts/tf/github.com/da-project/team.tf
+++ b/scripts/tf/github.com/da-project/team.tf
@@ -1,18 +1,13 @@
-resource "github_team" "team" {
-  name    = var.group_name
-  privacy = "closed"
-  parent_team_id = var.parent_team_id == "" ? null : var.parent_team_id
-}
-
-resource "github_team_membership" "member" {
-  count    = length(var.members)
-  team_id  = github_team.team.id
-  username = var.members[count.index]
-  role     = "maintainer"
+module "team" {
+  source              = "../da-teams"
+  group_name          = var.group_name
+  group_role          = "maintainer"
+  parent_team_id      = var.parent_team_id
+  members             = var.members
 }
 
 resource "github_team_repository" "team_repo" {
-  team_id    = github_team.team.id
+  team_id    = module.team.id
   repository = github_repository.repo.name
   permission = "maintain"
 }

--- a/scripts/tf/github.com/da-project/variables.tf
+++ b/scripts/tf/github.com/da-project/variables.tf
@@ -1,14 +1,14 @@
 variable "group_name" {
   type = string
 }
+
 variable "members" {
   type = list
 }
-variable "github_organization" {
+
+variable "admins_team_id" {
+  type = string
 }
-variable "github_token" {
-}
-variable "admins_team_id"{}
 
 variable "parent_team_id" {
   type = string

--- a/scripts/tf/github.com/da-teams/output.tf
+++ b/scripts/tf/github.com/da-teams/output.tf
@@ -1,3 +1,3 @@
-output "team_id" {
+output "id" {
   value = github_team.team.id
 }

--- a/scripts/tf/github.com/da-teams/team.tf
+++ b/scripts/tf/github.com/da-teams/team.tf
@@ -1,11 +1,16 @@
+locals {
+  members = { for v in var.members : v => v }
+}
+
 resource "github_team" "team" {
-  name    = var.group_name
-  privacy = "closed"
+  name           = var.group_name
+  privacy        = var.privacy
+  parent_team_id = var.parent_team_id
 }
 
 resource "github_team_membership" "member" {
-  count    = length(var.members)
+  for_each = local.members
   team_id  = github_team.team.id
-  username = var.members[count.index].name
-  role     = var.members[count.index].role
+  username = each.value
+  role     = var.group_role
 }

--- a/scripts/tf/github.com/da-teams/variables.tf
+++ b/scripts/tf/github.com/da-teams/variables.tf
@@ -1,10 +1,17 @@
-variable "github_organization" {
-}
-variable "github_token" {
-}
 variable "group_name" {
   type = string
 }
 variable "members" {
   type = list
+}
+variable "group_role" {
+  type = string
+}
+variable "parent_team_id" { 
+  type    = string
+  default = null
+}
+variable "privacy" { 
+  type    = string
+  default = "closed"
 }

--- a/scripts/tf/github.com/playground-repo.tf
+++ b/scripts/tf/github.com/playground-repo.tf
@@ -12,13 +12,13 @@ resource "github_repository" "playground-repository" {
 }
 
 resource "github_team_repository" "playground-admins_access" {
-  team_id    = module.team-admins.team_id
+  team_id    = module.team-admins.id
   repository = github_repository.playground-repository.name
   permission = "admin"
 }
 
 resource "github_team_repository" "playground-instructors_access" {
-  team_id    = module.team-instructors.team_id
+  team_id    = module.team-instructors.id
   repository = github_repository.playground-repository.name
   permission = "admin"
 }

--- a/scripts/tf/github.com/team-admins.tf
+++ b/scripts/tf/github.com/team-admins.tf
@@ -1,20 +1,10 @@
 module "team-admins" {
   source              = "./da-teams"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "admin"
+  group_role          = "maintainer"
   members             = [
-    {
-      name: "caiocezart",
-      role: "maintainer"
-    },
-    {
-      name: "denstorti",
-      role: "maintainer"
-    },
-    {
-      name: "kikobr82",
-      role: "maintainer"
-    }
+    "caiocezart",
+    "denstorti",
+    "kikobr82"
   ]
 }

--- a/scripts/tf/github.com/team-external-students.tf
+++ b/scripts/tf/github.com/team-external-students.tf
@@ -1,45 +1,17 @@
 module "team-external-students" {
   source              = "./da-teams"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "external-students"
+  group_role          = "member"
   members             = [
-    {
-      name: "afaryy",
-      role: "member"
-    },
-    {
-      name: "albertoeks",
-      role: "member"
-    },
-    {
-      name: "carloshz4",
-      role: "member"
-    },
-    {
-      name: "ebeserra"
-      role: "member"
-    },
-    {
-      name: "maladham1980",
-      role: "member"
-    },
-    {
-      name: "raghunadhpokkalath",
-      role: "member"
-    },
-    {
-      name: "rodrigovcesar",
-      role: "member"
-    },
-    {
-      name: "roperto",
-      role: "member"
-    },
-    {
-      name: "ramiray",
-      role: "member"
-    }
+    "afaryy",
+    "albertoeks",
+    "carloshz4",
+    "ebeserra",
+    "maladham1980",
+    "raghunadhpokkalath",
+    "rodrigovcesar",
+    "roperto",
+    "ramiray"
   ]
 }
 

--- a/scripts/tf/github.com/team-instructors.tf
+++ b/scripts/tf/github.com/team-instructors.tf
@@ -1,20 +1,11 @@
 module "team-instructors" {
   source              = "./da-teams"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "instructors"
+  group_role          = "maintainer"
   members             = [
-    {
-      name: "caiocezart",
-      role: "maintainer"
-    },
-    {
-      name: "denstorti",
-      role: "maintainer"
-    },
-    {
-      name: "kikobr82",
-      role: "maintainer"
-    }
+    "caiocezart",
+    "denstorti",
+    "kikobr82",
+    "omarst9"
   ]
 }

--- a/scripts/tf/github.com/team-reviewers.tf
+++ b/scripts/tf/github.com/team-reviewers.tf
@@ -1,16 +1,9 @@
 module "team-reviewers" {
   source              = "./da-teams"
-  github_token        = var.github_token
-  github_organization = var.github_organization
   group_name          = "reviewers"
+  group_role          = "member"
   members             = [
-    {
-      name: "deniseddi",
-      role: "member"
-    },
-    {
-      name: "starkmatt",
-      role: "member"
-    },
+    "deniseddi",
+    "starkmatt"
   ]
 }


### PR DESCRIPTION
Terraform resources using count will replace items if the order is changed. That way students were receiving email alerts every time that they were removed/added from groups.

I have now updated the code to use `for_each` instead. Used the opportunity to improve the code a bit and remove some unnecessary parts.