### PR TITLE
Add README.md & cli_commands.txt for exercise c04-iam01

### DIFF
--- a/classes/02class/exercises/c04-iam01/mrcsmonteiro/README.md
+++ b/classes/02class/exercises/c04-iam01/mrcsmonteiro/README.md
@@ -1,0 +1,9 @@
+# c04-iam01
+
+## Command Execution Output
+- [cli_commands.txt](cli_commands.txt)
+
+***
+Answer for exercise [c04-iam01](https://github.com/devopsacademyau/academy/blob/4d3701fa0791064e8a5b737acae52c992faaa07e/classes/04class/exercises/c04-iam01/README.md)
+
+

--- a/classes/02class/exercises/c04-iam01/mrcsmonteiro/cli_commands.txt
+++ b/classes/02class/exercises/c04-iam01/mrcsmonteiro/cli_commands.txt
@@ -1,0 +1,92 @@
+# 1. Create a new IAM User called user_readonly_S3
+
+$ aws iam create-user \
+    --user-name user_readonly_S3 \
+    --tags Key=Name,Value="DevOps Academy S3 Read Only User"
+
+{
+    "User": {
+        "Path": "/",
+        "UserName": "user_readonly_S3",
+        "UserId": "AIDASFVNJCSCA4XQ6SZOQ",
+        "Arn": "arn:aws:iam::149613515908:user/user_readonly_S3",
+        "CreateDate": "2020-06-27T05:38:57+00:00",
+        "Tags": [
+            {
+                "Key": "Name",
+                "Value": "DevOps Academy S3 Read Only User"
+            }
+        ]
+    }
+}
+
+# 2. Create a new Policy called S3readOnly that ALLOWS only S3 reads on every S3 resource. Take note of the created Policy ARN.
+
+cat << EOF > ~/AWS/policies/devops-academy-s3readonly.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:Get*",
+                "s3:List*"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*"
+            ]
+        }
+    ]
+}
+EOF
+
+$ aws iam create-policy \
+    --policy-name S3readOnly \
+    --policy-document file://~/AWS/policies/devops-academy-s3readonly.json
+
+{
+    "Policy": {
+        "PolicyName": "S3readOnly",
+        "PolicyId": "ANPASFVNJCSCDXTSZQRSG",
+        "Arn": "arn:aws:iam::149613515908:policy/S3readOnly",
+        "Path": "/",
+        "DefaultVersionId": "v1",
+        "AttachmentCount": 0,
+        "PermissionsBoundaryUsageCount": 0,
+        "IsAttachable": true,
+        "CreateDate": "2020-06-27T05:47:33+00:00",
+        "UpdateDate": "2020-06-27T05:47:33+00:00"
+    }
+}
+
+# 3. Attach the policy to the user
+
+$ aws iam attach-user-policy \
+    --policy-arn arn:aws:iam::149613515908:policy/S3readOnly \
+    --user-name user_readonly_S3
+
+# 4. Create a new Access Key (and secret) for this new user.
+
+$ aws iam create-access-key \
+    --user-name user_readonly_S3 > ~/AWS/my_keys/devops_academy_user_readonly_s3.txt
+
+# 5. Configure a new AWS CLI profile called s3ReadOnlyProfile using the credentials from the previous step.
+
+$ aws configure --profile s3ReadOnlyProfile
+AWS Access Key ID [None]: <my_access_key_id>
+AWS Secret Access Key [None]: <my_secret_access_key>
+Default region name [None]: ap-southeast-2
+Default output format [None]: json
+
+# 6. Check user permissions.
+
+$ aws sts get-caller-identity --profile s3ReadOnlyProfile
+
+{
+    "UserId": "AIDASFVNJCSCA4XQ6SZOQ",
+    "Account": "149613515908",
+    "Arn": "arn:aws:iam::149613515908:user/user_readonly_S3"
+}
+
+$ aws s3 ls --profile s3ReadOnlyProfile
+2020-06-12 20:25:52 mrcsmonteiro-devops-academy-bucket


### PR DESCRIPTION
# Description

Exercise (e.g. C01-E01):  c04-iam01

Student Name: Marcos Monteiro

> Create IAM user + policy and access key for S3 read only access via AWS CLI.

## Type of change

- [x] Exercise Submission (one exercise per PR)
  - [x] This PR is just for **one** exercise of a class
  - [x] PR name follows the pattern `<github-username>/<exercise-number>`
  - [x] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
