### PR TITLE
fix the dashboard when there is more than 30 PRs

### DIFF
--- a/scripts/dashboard/dashboard.sh
+++ b/scripts/dashboard/dashboard.sh
@@ -16,7 +16,7 @@ fi
 
 mkdir ${BASEDIR}/results
 
-curl ${TOKEN} ${GITHUB_URL}/pulls?state=open --silent| \
+curl ${TOKEN} "${GITHUB_URL}/pulls?state=open&per_page=100" --silent| \
     grep "\"number\":"| \
     cut -f2 -d":"| \
     cut -f1 -d ","| \


### PR DESCRIPTION
# Description

Exercise (e.g. C01-E01): 

Student Name:

> A brief explanation of what has been done.

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [X] Repo management
