### PR TITLE
Fixed markdown table headers

### DIFF
--- a/classes/02class/exercises/c02-network02/ANSWER.md
+++ b/classes/02class/exercises/c02-network02/ANSWER.md
@@ -5,7 +5,7 @@
 - Answers for `10.0.0.0/16`:
 
 |Subnet|Network|Host Range|Usable Hosts|Broadcast|AWS Reserved|
-|-|-|-|-|-|-|
+|---|---|---|---|---|---|
 |subnet-a| | | | |
 |subnet-b| | | | |
 |subnet-c| | | | |
@@ -14,7 +14,7 @@
 - Answers for `192.168.0.0/24`:
 
 |Subnet|Network|Host Range|Usable Hosts|Broadcast|AWS Reserved|
-|-|-|-|-|-|-|
+|---|---|---|---|---|---|
 |subnet-a| | | | |
 |subnet-b| | | | |
 |subnet-c| | | | |


### PR DESCRIPTION
# Description

According to the markdown syntax, table headers must be separated by at least 3 hyphens `---`.

See https://www.markdownguide.org/extended-syntax/#tables

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [X] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
