### PR TITLE
Small fixes: class03/docker

### DIFF
--- a/classes/03class/docker/README.md
+++ b/classes/03class/docker/README.md
@@ -99,7 +99,9 @@ Below you have some of the most common commands used in the docker client.
     - Execute an action related to containers
 - docker image [action]
     - Execute an action related to images
-
+- docker logs [container id]
+    - Fetch the logs of a container
+    
 Reference for all Docker client commands and options: [https://docs.docker.com/engine/reference/commandline/docker/](https://docs.docker.com/engine/reference/commandline/docker/)
 
 ## Registries
@@ -151,7 +153,7 @@ CMD [ "/app/app1.bin", "run" ]
 - CMD
   - Set a default command and default parameters which will be executed when Docker is run. Those values can be overwritten during the container execution
 - ENTRYPOINT
-  - Used when the container needs to be run as an executable. The command inside ENTRYPOINT instruction will can't be overwritten during container execution.
+  - Used when the container needs to be run as an executable.
 - WORKDIR
   - Sets the working directory to run the instructions: RUN, CMD, ENTRYPOINT, COPY and ADD
 


### PR DESCRIPTION
# Description

 You can override the ENTRYPOINT instruction using the docker run --entrypoint flag

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [x] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
