### PR TITLE
Exercise Update: remove output.md file requirement for c03-make01

### DIFF
--- a/classes/03class/exercises/c03-make01/ANSWER.md
+++ b/classes/03class/exercises/c03-make01/ANSWER.md
@@ -24,4 +24,4 @@ Insert command and output here
 <!-- Don't change anything below this point-->
 <!-- Before commiting, remove both commented lines--> 
 ***
-Answer for exercise [c03-make01](https://github.com/devopsacademyau/academy/blob/2ebc8b7a44410bb2bacf7d50f55a9ecfb6f20d1b/classes/03class/exercises/c03-make01/README.md)
+Answer for exercise [c03-make01](https://github.com/devopsacademyau/academy/blob/8b64a93a228398e7342afe7b845cd197b22afaf3/classes/03class/exercises/c03-make01/README.md)

--- a/classes/03class/exercises/c03-make01/ANSWER.md
+++ b/classes/03class/exercises/c03-make01/ANSWER.md
@@ -3,7 +3,6 @@
 ## Make
 - [Dockerfile](Dockerfile)
 - [Makefile](Makefile)
-- [output.md](output.md)
 
 ## Command Execution Output
 
@@ -25,4 +24,4 @@ Insert command and output here
 <!-- Don't change anything below this point-->
 <!-- Before commiting, remove both commented lines--> 
 ***
-Answer for exercise [c03-make01](https://github.com/devopsacademyau/academy/blob/af3225a3436f263164e8daebc6bbd1ef3122b900/classes/03class/exercises/c03-make01/README.md)
+Answer for exercise [c03-make01](https://github.com/devopsacademyau/academy/blob/2ebc8b7a44410bb2bacf7d50f55a9ecfb6f20d1b/classes/03class/exercises/c03-make01/README.md)

--- a/classes/03class/exercises/c03-make01/README.md
+++ b/classes/03class/exercises/c03-make01/README.md
@@ -22,6 +22,4 @@ Your Makefile should have the following steps:
     - Dockerfile
         - with the instructions to build your docker image
     - Makefile
-        - with the three phony targets mentioned above 
-    - output.md
-        - with the execution and outputs of the following command: `make build`, `make push`, `make run`
+        - with the three phony targets mentioned above


### PR DESCRIPTION
# Description

> The command output should be placed on README.md (based on ANSWERS.md). Hence, the **output.md** file is no longer required.

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [x] Documentation update
- [ ] Repo management
