### PR TITLE
Fix content in ANSWER.md and README.md

### DIFF
--- a/classes/02class/exercises/c02-network01/ANSWER.md
+++ b/classes/02class/exercises/c02-network01/ANSWER.md
@@ -5,40 +5,40 @@
 - Answers for `10.0.0.1/24`:
 
   - IP in binary: ``
-  - subnet in binary: `` 
-  - subnet in decimals: ``
+  - netmask in binary: `` 
+  - netmask in decimals: ``
   - private/public: ``
   - hosts: ``
 
 - Answers for `192.168.0.1/16`:
 
   - IP in binary: ``
-  - subnet in binary: `` 
-  - subnet in decimals: ``
+  - netmask in binary: `` 
+  - netmask in decimals: ``
   - private/public: ``
   - hosts: ``
 
 - Answers for `249.165.166.135/30`:
 
   - IP in binary: ``
-  - subnet in binary: `` 
-  - subnet in decimals: ``
+  - netmask in binary: `` 
+  - netmask in decimals: ``
   - private/public: ``
   - hosts: ``
 
 - Answers for `236.68.223.18/32`:
 
   - IP in binary: ``
-  - subnet in binary: `` 
-  - subnet in decimals: ``
+  - netmask in binary: `` 
+  - netmask in decimals: ``
   - private/public: ``
   - hosts: ``
 
 - Answers for `172.31.0.0/16`:
 
   - IP in binary: ``
-  - subnet in binary: `` 
-  - subnet in decimals: ``
+  - netmask in binary: `` 
+  - netmask in decimals: ``
   - private/public: ``
   - hosts: ``
 

--- a/classes/02class/exercises/c02-network01/README.md
+++ b/classes/02class/exercises/c02-network01/README.md
@@ -3,16 +3,16 @@
 ### For each given IPv4 address and network prefix (CIDR), please determine:
 
 - IP in binary
-- subnet in binary
-- subnet in decimals
+- netmask in binary
+- netmask in decimals
 - is it private or public?
 - how many IP addresses for HOSTS are available on subnets (not necessarily AWS ones) -- if you wish to do for AWS subnets type, just state your decision.
 
 - Example: `192.168.0.1/24`
 
-IP in binary: `11000000.10101000.00000000 .00000001`
-subnet in binary: `11111111.11111111.11111111 .00000000`
-subnet in decimals: `255.255.255.0`
+IP in binary: `11000000.10101000.00000000.00000001`
+netmask in binary: `11111111.11111111.11111111.00000000`
+netmask in decimals: `255.255.255.0`
 private/public: `private`
 hosts: `251`
 


### PR DESCRIPTION
# Description

Exercise (e.g. C01-E01): 

Student Name:

> Fixes terminology of netmask for ANSWER.md and README.md.  Removes incorrect blank space in README.md

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
