### PR TITLE
fix exercise c03-aws01: remove https from the link-local address

### DIFF
--- a/classes/03class/exercises/c03-aws01/README.md
+++ b/classes/03class/exercises/c03-aws01/README.md
@@ -22,7 +22,7 @@ systemctl start httpd
 Questions:
 
 - access through your browser each instance IP on port 80 `http://<instance-ip>` and post the hostname of each one
-- what this line is doing? `curl https://169.254.169.254/latest/meta-data/hostname > index.html`
+- what this line is doing? `curl 169.254.169.254/latest/meta-data/hostname > index.html`
 
 ## Submit a PR with the following files
 


### PR DESCRIPTION
# Description

Exercise (e.g. C01-E01): 

Student Name:

> A brief explanation of what has been done.

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [x] Documentation update
- [ ] Repo management
