### PR TITLE
fix alanlima/c04-iac02

### DIFF
--- a/classes/04class/exercises/c04-iac02/alanlima/vpc.tf
+++ b/classes/04class/exercises/c04-iac02/alanlima/vpc.tf
@@ -1,5 +1,5 @@
 resource "aws_vpc" "vpc_devops" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = var.vpc_cidr
   tags = merge(var.common_tags, {
     Name = "devopsacademy-iac"
   })


### PR DESCRIPTION
# Description

Exercise (e.g. C01-E01): **c04-iac02**

Student Name: **Alan Lima**

> Small fix in the vpc file to use the variables instead of hardcore cidr_block

## Type of change

- [x] Exercise Submission (one exercise per PR)
  - [x] This PR is just for **one** exercise of a class
  - [x] PR name follows the pattern `<github-username>/<exercise-number>`
  - [x] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [x] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [ ] Repo management
