### PR TITLE
change httpd version to 2.4.51 - 2.4.48 no longer available

### DIFF
--- a/classes/03class/docker/artifacts/Dockerfile.Image1
+++ b/classes/03class/docker/artifacts/Dockerfile.Image1
@@ -3,6 +3,6 @@ WORKDIR tmp
 RUN echo "image change" > /tmp/devops.academy
 RUN apt-get update
 RUN apt-get -y install curl
-ADD http://apache.mirror.serversaustralia.com.au//httpd/httpd-2.4.48.tar.gz /tmp/
-RUN tar xzvf /tmp/httpd-2.4.48.tar.gz
-RUN rm -rf /tmp/httpd-2.4.48.tar.gz
+ADD http://apache.mirror.serversaustralia.com.au//httpd/httpd-2.4.51.tar.gz /tmp/
+RUN tar xzvf /tmp/httpd-2.4.51.tar.gz
+RUN rm -rf /tmp/httpd-2.4.51.tar.gz

--- a/classes/03class/docker/artifacts/Dockerfile.Image2
+++ b/classes/03class/docker/artifacts/Dockerfile.Image2
@@ -3,6 +3,6 @@ WORKDIR tmp
 RUN apt-get update && apt-get install -y \
     curl \
  && rm -rf /var/lib/apt/lists/*
-RUN curl -k http://apache.mirror.serversaustralia.com.au//httpd/httpd-2.4.48.tar.gz -o /tmp/httpd-2.4.48.tar.gz && \
-    tar xzvf /tmp/httpd-2.4.48.tar.gz && \
-    rm -rf /tmp/httpd-2.4.48.tar.gz
+RUN curl -k http://apache.mirror.serversaustralia.com.au//httpd/httpd-2.4.51.tar.gz -o /tmp/httpd-2.4.51.tar.gz && \
+    tar xzvf /tmp/httpd-2.4.51.tar.gz && \
+    rm -rf /tmp/httpd-2.4.51.tar.gz

--- a/classes/03class/docker/artifacts/Dockerfile.Image3
+++ b/classes/03class/docker/artifacts/Dockerfile.Image3
@@ -3,8 +3,8 @@ WORKDIR tmp
 RUN apt-get update && apt-get install -y \
     curl \
  && rm -rf /var/lib/apt/lists/*
-RUN curl -k http://apache.mirror.serversaustralia.com.au//httpd/httpd-2.4.48.tar.gz -o /tmp/httpd-2.4.48.tar.gz && \
-    tar xzvf /tmp/httpd-2.4.48.tar.gz && \
-    rm -rf /tmp/httpd-2.4.48.tar.gz
+RUN curl -k http://apache.mirror.serversaustralia.com.au//httpd/httpd-2.4.51.tar.gz -o /tmp/httpd-2.4.51.tar.gz && \
+    tar xzvf /tmp/httpd-2.4.51.tar.gz && \
+    rm -rf /tmp/httpd-2.4.51.tar.gz
 FROM ubuntu:18.04
 COPY --from=builder /tmp /tmp


### PR DESCRIPTION
# Description

This a fix for the Docker exercise in Class 03. 

Student Name: @beardedsamwise 

> A brief explanation of what has been done.

httpd 2.4.48 is no longer available in the repo which causes the docker image builds to fail. httpd in each Docker file has been updated to 2.4.51.

## Type of change

- [ ] Exercise Submission (one exercise per PR)
  - [ ] This PR is just for **one** exercise of a class
  - [ ] PR name follows the pattern `<github-username>/<exercise-number>`
  - [ ] Added exercise files inside folder `/classes/<class- number>/exercises/<exercise-number>/<github-username>/`
	- [ ] Review [exercise submission steps](./README.md#Exercises)
- [ ] Class content (instructors/admins)
- [ ] Documentation update
- [x] Repo management
